### PR TITLE
Fix in case of bs 5

### DIFF
--- a/src/CheckboxX.php
+++ b/src/CheckboxX.php
@@ -125,7 +125,7 @@ class CheckboxX extends InputWidget
             throw new InvalidConfigException("The 'initInputType' property must be one of '{$txt}' or '{$cbx}'.");
         }
         if (empty($this->pluginOptions['iconChecked'])) {
-            $this->pluginOptions['iconChecked'] = $this->isBs(4) || $this->pluginOptions['iconChecked'] = isBS(5) ? '<i class="fas fa-check"></i>' :
+            $this->pluginOptions['iconChecked'] = = ($this->isBs(4) || $this->isBs(5)) ? '<i class="fas fa-check"></i>' :
                 '<i class="glyphicon glyphicon-ok"></i>';
         }
 

--- a/src/CheckboxX.php
+++ b/src/CheckboxX.php
@@ -125,7 +125,7 @@ class CheckboxX extends InputWidget
             throw new InvalidConfigException("The 'initInputType' property must be one of '{$txt}' or '{$cbx}'.");
         }
         if (empty($this->pluginOptions['iconChecked'])) {
-            $this->pluginOptions['iconChecked'] = $this->isBs4() ? '<i class="fas fa-check"></i>' :
+            $this->pluginOptions['iconChecked'] = $this->isBs(4) || $this->pluginOptions['iconChecked'] = isBS(5) ? '<i class="fas fa-check"></i>' :
                 '<i class="glyphicon glyphicon-ok"></i>';
         }
 


### PR DESCRIPTION
## Scope
This pull request includes a

- [ x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
- adjust init function for correctly work in case of bs 5
- widget use glyph in case of bsVersion = 5.x instead of awesome font
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.